### PR TITLE
fix flame issue on macos due to incorrect hostname

### DIFF
--- a/firex_flame/flame_helper.py
+++ b/firex_flame/flame_helper.py
@@ -8,6 +8,8 @@ import signal
 from dataclasses import dataclass
 from typing import Optional, List, Union
 import hashlib
+import platform
+import socket
 
 from firexapp.submit.uid import Uid
 
@@ -96,11 +98,16 @@ def find_rec_file(log_dir):
     # Formerly was used for backwards compatability, now an alias for get_rec_file
     return get_rec_file(log_dir)
 
+def get_hostname():
+    myplatform = platform.system()
+    myhostname = socket.gethostname()
+    myhostname = f"{myhostname}.local" if myplatform== "Darwin" and not myhostname.endswith("local") else myhostname
+    return myhostname
+
 
 def get_flame_url(port: int, hostname=None) -> str:
     if hostname is None:
-        from socket import gethostname
-        hostname = gethostname()
+        hostname = get_hostname()
     return 'http://%s:%d' % (hostname, int(port))
 
 


### PR DESCRIPTION
fix flame issue on macos due to incorrect hostname

```
[venv] ashrif@ASHRIF-M-WFVP:~/workspace/firex/firexapp-fork ‹master›
$ firexapp submit --chain nop
[00:51:29][ASHRIF-M-WFVP] FireX ID: FireX-ashrif-240801-045129-50878
[00:51:29][ASHRIF-M-WFVP] Logs: /var/folders/jm/8cxk89jj3xb7xb5zrmqq9jyw0000gn/T/FireX-ashrif-240801-045129-50878
[00:51:30][ASHRIF-M-WFVP] Flame: http://ASHRIF-M-WFVP.local:57497

```